### PR TITLE
fix: throw a Forbidden error if username doesn't match

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -245,6 +245,10 @@ export default async function user(fastify) {
       }
       // We get the username from the logged in user, not from the query
       const username = req.user.username // 💡 <-- The fix is here!
+      // if the query username does not match with the user's one, return a 403 Forbidden error
+      if (username !== req.query.username) {
+        throw new errors.Forbidden()
+      }
       // (Skipping the rest of the function...)
       return user
     }

--- a/src/a01-access-control/routes/profile/solution.js
+++ b/src/a01-access-control/routes/profile/solution.js
@@ -13,6 +13,10 @@ export default async function solution(fastify) {
       }
       // We get the username from the logged in user, not from the query
       const username = req.user.username
+      // if the query username does not match with the user's one, return a 403 Forbidden error
+      if (username !== req.query.username) {
+        throw new errors.Forbidden()
+      }
       const {
         rows: [user]
       } = await fastify.pg.query(

--- a/src/a01-access-control/step1.test.js
+++ b/src/a01-access-control/step1.test.js
@@ -37,12 +37,7 @@ test('A01: Access Control', async t => {
         }
       })
 
-      t.equal(res.statusCode, 200)
-      t.same(res.json(), {
-        username: 'alice',
-        id: 1,
-        age: 23
-      })
+      t.equal(res.statusCode, 403)
     }
   )
 })


### PR DESCRIPTION
With the current implementation, in case of a mismatch between the username in the request and the one from the JWT,
the endpoints ignores the username in the request and just returns data for the authenticated user.

A more robust and correct behaviour would be to return a 403 Forbidden error.

Partially addresses #50 