### PR TITLE
feat: update notify-release config

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -6,6 +6,8 @@ on:
     - cron: '30 8 * * *'
   release:
     types: [published]
+  issues:
+    types: [closed]
 
 jobs:
   setup:


### PR DESCRIPTION
This PR adds the on closed issues trigger to the notify-release action, in order to handle the creation of a comment when a notify-release issue is snoozed.