### PR TITLE
fix: replace encryption with hashing

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -291,7 +291,7 @@ async req => {
 
 <div class="dense">
 
-- The `/all-data` endpoint returns all users and their passwords (encrypted in md5). Imagine this as a data breach
+- The `/all-data` endpoint returns all users and their passwords (hashed using md5). Imagine this as a data breach
 - Result of the `all-data` endpoint
 
 ```json
@@ -315,8 +315,8 @@ async req => {
 
 <div class="dense">
 
-- Using the `/all-data` route, find Alice's encrypted password
-- With this encrypted password hash, try to find the original unencrypted password Alice created
+- Using the `/all-data` route, find Alice's hashed password
+- With this password hash, try to find the original password Alice created
 - the Postman collection contains requests for doing the queries
 - 💡 There are websites to decrypt md5
 
@@ -328,8 +328,8 @@ async req => {
 
 <div class="dense">
 
-- md5 encryption is vulnerable and shouldn't be used
-- In `src/a02-cryptographic-failure`, fix the encryption used to be a strong algorithm instead of md5
+- md5 hash is vulnerable and shouldn't be used
+- In `src/a02-cryptographic-failure`, fix the hashing algorithm used to be a strong algorithm instead of md5
 - Using [bcrypt](https://www.npmjs.com/package/bcrypt) is a good idea for passwords
 - The application exposes a `/change-password` route used to change a user's password
 
@@ -342,12 +342,12 @@ async req => {
 <div class="dense">
 
 ```js
-// utils/encryption.js
+// utils/crypto.js
 import { hash, compare } from 'bcrypt'
 
 const saltRounds = 10
 
-export async function encryptPassword(password) {
+export async function hashPassword(password) {
   return await hash(password, saltRounds)
 }
 ```
@@ -361,7 +361,7 @@ export async function encryptPassword(password) {
 <div class="dense">
 
 ```js
-// utils/encryption.js
+// utils/crypto.js
 export async function comparePassword(password, hash) {
   return await compare(password, hash)
 }

--- a/src/a02-cryptographic-failure/routes/changePassword.js
+++ b/src/a02-cryptographic-failure/routes/changePassword.js
@@ -1,7 +1,7 @@
 import errors from 'http-errors'
 import { Type } from '@sinclair/typebox'
 import SQL from '@nearform/sql'
-import { encryptPassword } from '../utils/encryption.js'
+import { hashPassword } from '../utils/crypto.js'
 
 const schema = {
   body: Type.Object({
@@ -19,7 +19,7 @@ export default async function changePassword(fastify) {
     async req => {
       const { username } = req.user
       const { password } = req.body
-      const hashedPassword = await encryptPassword(password)
+      const hashedPassword = await hashPassword(password)
       const {
         rows: [user]
       } = await fastify.pg.query(

--- a/src/a02-cryptographic-failure/step2.test.js
+++ b/src/a02-cryptographic-failure/step2.test.js
@@ -26,7 +26,7 @@ test('A02: Cryptographic Failure', async t => {
     t.equal(res.statusCode, 200)
   })
 
-  t.test(`Password isn't encrypted with weak md5`, async t => {
+  t.test(`Password isn't hashed with weak md5`, async t => {
     const res = await fastify.inject({
       url: '/all-data',
       method: 'GET',

--- a/src/a02-cryptographic-failure/utils/crypto.js
+++ b/src/a02-cryptographic-failure/utils/crypto.js
@@ -2,7 +2,7 @@ import md5 from 'md5'
 import { getSolutionToExport } from 'owasp-shared/export-solution.js'
 import * as solution from './solution.js'
 
-let encryptPassword = async function encryptPassword(password) {
+let hashPassword = async function hashPassword(password) {
   return md5(password)
 }
 
@@ -11,7 +11,7 @@ let comparePassword = async function comparePassword(password, hash) {
 }
 
 // Note: This helper just helps with internal unit testing
-encryptPassword = getSolutionToExport(encryptPassword, solution.encryptPassword)
+hashPassword = getSolutionToExport(hashPassword, solution.hashPassword)
 comparePassword = getSolutionToExport(comparePassword, solution.comparePassword)
 
-export { encryptPassword, comparePassword }
+export { hashPassword, comparePassword }

--- a/src/a02-cryptographic-failure/utils/solution.js
+++ b/src/a02-cryptographic-failure/utils/solution.js
@@ -2,7 +2,7 @@ import { hash, compare } from 'bcrypt'
 
 const saltRounds = 10
 
-export async function encryptPassword(password) {
+export async function hashPassword(password) {
   return await hash(password, saltRounds)
 }
 

--- a/src/a07-authentication-failures/routes/user/index.js
+++ b/src/a07-authentication-failures/routes/user/index.js
@@ -4,7 +4,7 @@ import errors from 'http-errors'
 import { Type } from '@sinclair/typebox'
 import SQL from '@nearform/sql'
 import { faker } from '@faker-js/faker'
-import { encryptPassword } from '../../../a02-cryptographic-failure/utils/encryption.js'
+import { hashPassword } from '../../../a02-cryptographic-failure/utils/crypto.js'
 
 const schema = {
   body: Type.Object({
@@ -22,7 +22,7 @@ export default async function register(fastify) {
   fastify.post('/register', { schema }, async req => {
     const { username, password } = req.body
     const age = faker.datatype.number({ min: 12, max: 85 })
-    const hashedPassword = await encryptPassword(password)
+    const hashedPassword = await hashPassword(password)
     const creditCardNumber = faker.finance.creditCardNumber('#'.repeat(16))
     const {
       rows: [user]

--- a/src/a07-authentication-failures/routes/user/solution.js
+++ b/src/a07-authentication-failures/routes/user/solution.js
@@ -2,7 +2,7 @@ import { Type } from '@sinclair/typebox'
 import errors from 'http-errors'
 import SQL from '@nearform/sql'
 import { faker } from '@faker-js/faker'
-import { encryptPassword } from '../../../a02-cryptographic-failure/utils/encryption.js'
+import { hashPassword } from '../../../a02-cryptographic-failure/utils/crypto.js'
 
 const schema = {
   body: Type.Object({
@@ -23,7 +23,7 @@ export function register(fastify) {
   fastify.post('/register', { schema }, async (req, res) => {
     const { username, password } = req.body
     const age = faker.datatype.number({ min: 12, max: 85 })
-    const hashedPassword = await encryptPassword(password)
+    const hashedPassword = await hashPassword(password)
     const creditCardNumber = faker.finance.creditCardNumber('#'.repeat(16))
 
     const {

--- a/src/shared/routes/login.js
+++ b/src/shared/routes/login.js
@@ -1,7 +1,7 @@
 import errors from 'http-errors'
 import { Type } from '@sinclair/typebox'
 import SQL from '@nearform/sql'
-import { comparePassword } from '../../a02-cryptographic-failure/utils/encryption.js'
+import { comparePassword } from '../../a02-cryptographic-failure/utils/crypto.js'
 
 const schema = {
   body: Type.Object({

--- a/src/shared/routes/register.js
+++ b/src/shared/routes/register.js
@@ -2,7 +2,7 @@ import errors from 'http-errors'
 import { Type } from '@sinclair/typebox'
 import SQL from '@nearform/sql'
 import { faker } from '@faker-js/faker'
-import { encryptPassword } from '../../a02-cryptographic-failure/utils/encryption.js'
+import { hashPassword } from '../../a02-cryptographic-failure/utils/crypto.js'
 
 const schema = {
   body: Type.Object({
@@ -20,7 +20,7 @@ export default async function register(fastify) {
   fastify.post('/register', { schema }, async req => {
     const { username, password } = req.body
     const birthDate = faker.date.past()
-    const hashedPassword = await encryptPassword(password)
+    const hashedPassword = await hashPassword(password)
     const creditCardNumber = faker.finance.creditCardNumber()
     const {
       rows: [user]


### PR DESCRIPTION
Fix slides and code that use hashing algorithm
but describe it as an encryption algorithm.

Encryption is a two-way function where information 
is scrambled in such a way that it can be unscrambled later.

Hashing is a one-way function where data
is mapped to a fixed-length value.

Fixes #246 