### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "owasp-top-ten-workshop",
   "private": true,
   "type": "module",
-  "workspaces": ["src/*"],
+  "workspaces": [
+    "src/*"
+  ],
   "version": "1.0.0",
   "license": "CC-BY-SA-4.0",
   "author": "Liana Pigeot <liana.pigeot@nearform.com>",
@@ -21,7 +23,7 @@
     "verify": "npm run verify --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "eslint .",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@faker-js/faker": "^8.4.1",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)